### PR TITLE
Fix: Parameterize Host and Validation URL based on system environment…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bfabric @ file:///home/gwhite/APPLICATIONS/bfabric-app-barcode/bfabricPy/dist/bfabric-0.13.7.tar.gz#sha256=0f82992de7ceaffe5e1647711b22c14100aff356dfeb1d68a097f8a4489cc729
 blinker==1.8.2
 certifi==2024.6.2
 charset-normalizer==3.3.2

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -40,13 +40,15 @@ def token_to_data(token: str) -> str:
         if not five_minutes_later <= datetime.datetime.strptime(expiry_time, "%Y-%m-%d %H:%M:%S"):
             return "EXPIRED"
         
+        environment_dict = {"Production":"https://fgcz-bfabric.uzh.ch/bfabric","Test":"https://fgcz-bfabric-test.uzh.ch/bfabric"}
+
         token_data = dict(
             environment = userinfo['environment'],
             user_data = userinfo['user'],
             token_expires = expiry_time,
             entity_id_data = userinfo['entityId'],
             entityClass_data = userinfo['entityClassName'],
-            webbase_data = validation_url.split('rest')[0],
+            webbase_data = environment_dict.get(userinfo['environment'], None),
             application_params_data = {},
             application_data = str(userinfo['applicationId']),
             userWsPassword = userinfo['userWsPassword']


### PR DESCRIPTION
I made updates to utils/auth_utils.py based on the changes we discussed together on Thursday, 29.10.2024. With these adjustments, the deployment now works correctly with test-only accounts.

Additionally, I removed the -bfabric @ ... entry from requirements.txt because it was a hardcoded link that didn’t work in my environment. Please let me know if this causes any issues.